### PR TITLE
Compatibility with Noetic and Melodic

### DIFF
--- a/rotors_description/urdf/m100_base.xacro
+++ b/rotors_description/urdf/m100_base.xacro
@@ -62,9 +62,9 @@
   <xacro:arg name="gpu" default="false"/>
   <xacro:property name="gpu" value="$(arg gpu)" />
   <xacro:include filename="$(find lidar_description)/urdf/VLP-16.urdf.xacro"/>
-  <VLP-16 parent="${namespace}/base_link" name="${namespace}/velodyne" topic="/velodyne_points" hz="10" samples="440" gpu="${gpu}">
+  <xacro:VLP-16 parent="${namespace}/base_link" name="${namespace}/velodyne" topic="/velodyne_points" hz="10" samples="440" gpu="${gpu}">
     <origin xyz="0 0 0.04" rpy="0 0 0" />
-  </VLP-16>
+  </xacro:VLP-16>
 
 </robot>
 

--- a/rotors_gazebo/CMakeLists.txt
+++ b/rotors_gazebo/CMakeLists.txt
@@ -26,7 +26,7 @@ if(${gazebo_VERSION_MAJOR} GREATER 2)
     add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/models/iris/iris.sdf
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
       COMMAND rm -f ${CMAKE_CURRENT_SOURCE_DIR}/models/iris/iris.sdf
-      COMMAND python ${scripts_dir}/xacro.py -o  ${rotors_description_dir}/urdf/iris_base.urdf  ${rotors_description_dir}/urdf/iris_base.xacro enable_mavlink_interface:=${enable_mavlink_interface} enable_ground_truth:=${enable_ground_truth} enable_wind:=${enable_wind} enable_logging:=${enable_logging} rotors_description_dir:=${rotors_description_dir}
+      COMMAND python3 ${scripts_dir}/xacro.py -o  ${rotors_description_dir}/urdf/iris_base.urdf  ${rotors_description_dir}/urdf/iris_base.xacro enable_mavlink_interface:=${enable_mavlink_interface} enable_ground_truth:=${enable_ground_truth} enable_wind:=${enable_wind} enable_logging:=${enable_logging} rotors_description_dir:=${rotors_description_dir}
       COMMAND gz sdf -p  ${rotors_description_dir}/urdf/iris_base.urdf >> ${CMAKE_CURRENT_SOURCE_DIR}/models/iris/iris.sdf
       COMMAND rm -f ${rotors_description_dir}/urdf/iris_base.urdf
       DEPENDS ${rotors_description_dir}/urdf/iris.xacro

--- a/rotors_gazebo_plugins/CMakeLists.txt
+++ b/rotors_gazebo_plugins/CMakeLists.txt
@@ -8,7 +8,7 @@
 #                                               if BUILD_MAVLINK_INTERFACE_PLUGIN=TRUE.
 # NO_ROS                            bool    Build without any ROS dependencies.
 
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rotors_gazebo_plugins)
 
 #
@@ -83,7 +83,7 @@ else()
 endif()
 
 # Specify C++11 standard
-add_definitions(-std=c++11)
+add_definitions(-std=c++14)
 
 # Provides a compiler flag notifying the preprocessor about
 # the MAVLink Interface plugin build status
@@ -140,6 +140,7 @@ find_package(Glog REQUIRED)
 link_directories(${GAZEBO_LIBRARY_DIRS})
 include_directories(${GAZEBO_INCLUDE_DIRS})
 include_directories(${OpenCV_INCLUDE_DIRS})
+message(WARNING RotosS_Gazebo_Plugin Opencv Dir: ${OpenCV_INCLUDE_DIRS})
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 

--- a/rotors_gazebo_plugins/src/external/gazebo_geotagged_images_plugin.cpp
+++ b/rotors_gazebo_plugins/src/external/gazebo_geotagged_images_plugin.cpp
@@ -22,9 +22,8 @@
 #include <iostream>
 
 #include <boost/filesystem.hpp>
-#include <cv.h>
-#include <highgui.h>
 #include <opencv2/opencv.hpp>
+#include <opencv2/highgui/highgui.hpp>
 
 #include "rotors_gazebo_plugins/common.h"
 
@@ -140,7 +139,8 @@ void GeotaggedImagesPlugin::OnNewFrame(const unsigned char * image)
   Mat frame = Mat(height_, width_, CV_8UC3);
   Mat frameBGR = Mat(height_, width_, CV_8UC3);
   frame.data = (uchar*)image; //frame has not the right color format yet -> convert
-  cvtColor(frame, frameBGR, CV_RGB2BGR);
+  // cvtColor(frame, frameBGR, CV_RGB2BGR);
+  cvtColor(frame, frameBGR, cv::COLOR_RGB2BGR);
 
   char file_name[256];
   snprintf(file_name, sizeof(file_name), "%s/DSC%05i.jpg", storageDir_.c_str(), imageCounter_);

--- a/rotors_gazebo_plugins/src/gazebo_odometry_plugin.cpp
+++ b/rotors_gazebo_plugins/src/gazebo_odometry_plugin.cpp
@@ -89,7 +89,8 @@ void GazeboOdometryPlugin::Load(physics::ModelPtr _model,
   if (_sdf->HasElement("covarianceImage")) {
     std::string image_name =
         _sdf->GetElement("covarianceImage")->Get<std::string>();
-    covariance_image_ = cv::imread(image_name, CV_LOAD_IMAGE_GRAYSCALE);
+    // covariance_image_ = cv::imread(image_name, CV_LOAD_IMAGE_GRAYSCALE);
+    covariance_image_ = cv::imread(image_name, cv::IMREAD_GRAYSCALE);
     if (covariance_image_.data == NULL)
       gzerr << "loading covariance image " << image_name << " failed"
             << std::endl;


### PR DESCRIPTION
This PR will ensure that the branch `dev/arl_planners_gazeo9` will work equally well on melodic and noetic. 

Some file paths are changed and an issue for simulated lidar not showing up in gazebo 11.5 is resolved by adding `xacro` tag to the `m100_base.xacro` file.